### PR TITLE
Fixed typo in code

### DIFF
--- a/solutions/s-chapter9.md
+++ b/solutions/s-chapter9.md
@@ -184,7 +184,7 @@ The solution:
 
 ```java
 List<Movie> mySelection = Movies.movies().stream()
-   .filter(movie -> movie.time() < 2000)
+   .filter(movie -> movie.year() < 2000)
    .sorted(comparing(Movie::time).reversed())
    .limit(3)
    .sorted(comparing(Movie::title).reversed())


### PR DESCRIPTION
Fixed typo in Exercise 9, where `movie.time()` should be `movie.year()`